### PR TITLE
Add typings, no Implicit Any

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 /.dist/
 /jspm_packages/
 /node_modules/
+/typings/
 
 /aws.json
 /npm-debug.log

--- a/config/systemjs.config.js
+++ b/config/systemjs.config.js
@@ -545,6 +545,7 @@ System.config({
     "rxjs": "npm:rxjs@5.0.0-beta.2",
     "ts": "github:frankwallis/plugin-typescript@4.0.2",
     "typescript": "npm:typescript@1.8.7",
+    "typings": "npm:typings@0.6.10",
     "zone.js": "npm:zone.js@0.5.15",
     "github:frankwallis/plugin-typescript@4.0.2": {
       "typescript": "npm:typescript@1.8.7"
@@ -564,11 +565,41 @@ System.config({
     "github:jspm/nodelibs-events@0.1.1": {
       "events": "npm:events@1.0.2"
     },
+    "github:jspm/nodelibs-http@1.7.1": {
+      "Base64": "npm:Base64@0.2.1",
+      "events": "github:jspm/nodelibs-events@0.1.1",
+      "inherits": "npm:inherits@2.0.1",
+      "stream": "github:jspm/nodelibs-stream@0.1.0",
+      "url": "github:jspm/nodelibs-url@0.1.0",
+      "util": "github:jspm/nodelibs-util@0.1.0"
+    },
+    "github:jspm/nodelibs-https@0.1.0": {
+      "https-browserify": "npm:https-browserify@0.0.0"
+    },
+    "github:jspm/nodelibs-net@0.1.2": {
+      "buffer": "github:jspm/nodelibs-buffer@0.1.0",
+      "crypto": "github:jspm/nodelibs-crypto@0.1.0",
+      "http": "github:jspm/nodelibs-http@1.7.1",
+      "net": "github:jspm/nodelibs-net@0.1.2",
+      "process": "github:jspm/nodelibs-process@0.1.2",
+      "stream": "github:jspm/nodelibs-stream@0.1.0",
+      "timers": "github:jspm/nodelibs-timers@0.1.0",
+      "util": "github:jspm/nodelibs-util@0.1.0"
+    },
+    "github:jspm/nodelibs-os@0.1.0": {
+      "os-browserify": "npm:os-browserify@0.1.2"
+    },
     "github:jspm/nodelibs-path@0.1.0": {
       "path-browserify": "npm:path-browserify@0.0.0"
     },
     "github:jspm/nodelibs-process@0.1.2": {
       "process": "npm:process@0.11.2"
+    },
+    "github:jspm/nodelibs-punycode@0.1.0": {
+      "punycode": "npm:punycode@1.3.2"
+    },
+    "github:jspm/nodelibs-querystring@0.1.0": {
+      "querystring": "npm:querystring@0.2.0"
     },
     "github:jspm/nodelibs-stream@0.1.0": {
       "stream-browserify": "npm:stream-browserify@1.0.0"
@@ -576,11 +607,37 @@ System.config({
     "github:jspm/nodelibs-string_decoder@0.1.0": {
       "string_decoder": "npm:string_decoder@0.10.31"
     },
+    "github:jspm/nodelibs-timers@0.1.0": {
+      "timers-browserify": "npm:timers-browserify@1.4.2"
+    },
+    "github:jspm/nodelibs-tty@0.1.0": {
+      "tty-browserify": "npm:tty-browserify@0.0.0"
+    },
+    "github:jspm/nodelibs-url@0.1.0": {
+      "url": "npm:url@0.10.3"
+    },
     "github:jspm/nodelibs-util@0.1.0": {
       "util": "npm:util@0.10.3"
     },
     "github:jspm/nodelibs-vm@0.1.0": {
       "vm-browserify": "npm:vm-browserify@0.0.4"
+    },
+    "github:jspm/nodelibs-zlib@0.1.0": {
+      "browserify-zlib": "npm:browserify-zlib@0.1.4"
+    },
+    "npm:abbrev@1.0.7": {
+      "assert": "github:jspm/nodelibs-assert@0.1.0",
+      "util": "github:jspm/nodelibs-util@0.1.0"
+    },
+    "npm:agent-base@2.0.1": {
+      "events": "github:jspm/nodelibs-events@0.1.1",
+      "extend": "npm:extend@3.0.0",
+      "http": "github:jspm/nodelibs-http@1.7.1",
+      "https": "github:jspm/nodelibs-https@0.1.0",
+      "process": "github:jspm/nodelibs-process@0.1.2",
+      "semver": "npm:semver@5.0.3",
+      "url": "github:jspm/nodelibs-url@0.1.0",
+      "util": "github:jspm/nodelibs-util@0.1.0"
     },
     "npm:angular2@2.0.0-beta.8": {
       "crypto": "github:jspm/nodelibs-crypto@0.1.0",
@@ -591,6 +648,12 @@ System.config({
       "rxjs": "npm:rxjs@5.0.0-beta.2",
       "zone.js": "npm:zone.js@0.5.15"
     },
+    "npm:ansi-styles@2.2.0": {
+      "color-convert": "npm:color-convert@1.0.0"
+    },
+    "npm:any-promise@1.1.0": {
+      "process": "github:jspm/nodelibs-process@0.1.2"
+    },
     "npm:asn1.js@4.5.1": {
       "assert": "github:jspm/nodelibs-assert@0.1.0",
       "bn.js": "npm:bn.js@4.10.5",
@@ -600,11 +663,70 @@ System.config({
       "minimalistic-assert": "npm:minimalistic-assert@1.0.0",
       "vm": "github:jspm/nodelibs-vm@0.1.0"
     },
+    "npm:asn1@0.2.3": {
+      "assert": "github:jspm/nodelibs-assert@0.1.0",
+      "buffer": "github:jspm/nodelibs-buffer@0.1.0",
+      "sys": "github:jspm/nodelibs-util@0.1.0",
+      "util": "github:jspm/nodelibs-util@0.1.0"
+    },
+    "npm:assert-plus@0.2.0": {
+      "assert": "github:jspm/nodelibs-assert@0.1.0",
+      "buffer": "github:jspm/nodelibs-buffer@0.1.0",
+      "process": "github:jspm/nodelibs-process@0.1.2",
+      "stream": "github:jspm/nodelibs-stream@0.1.0",
+      "util": "github:jspm/nodelibs-util@0.1.0"
+    },
+    "npm:assert-plus@1.0.0": {
+      "assert": "github:jspm/nodelibs-assert@0.1.0",
+      "buffer": "github:jspm/nodelibs-buffer@0.1.0",
+      "process": "github:jspm/nodelibs-process@0.1.2",
+      "stream": "github:jspm/nodelibs-stream@0.1.0",
+      "util": "github:jspm/nodelibs-util@0.1.0"
+    },
     "npm:assert@1.3.0": {
       "util": "npm:util@0.10.3"
     },
+    "npm:async@1.5.2": {
+      "process": "github:jspm/nodelibs-process@0.1.2"
+    },
+    "npm:aws-sign2@0.6.0": {
+      "crypto": "github:jspm/nodelibs-crypto@0.1.0",
+      "url": "github:jspm/nodelibs-url@0.1.0"
+    },
+    "npm:aws4@1.3.2": {
+      "buffer": "github:jspm/nodelibs-buffer@0.1.0",
+      "crypto": "github:jspm/nodelibs-crypto@0.1.0",
+      "lru-cache": "npm:lru-cache@4.0.0",
+      "process": "github:jspm/nodelibs-process@0.1.2",
+      "querystring": "github:jspm/nodelibs-querystring@0.1.0",
+      "url": "github:jspm/nodelibs-url@0.1.0"
+    },
+    "npm:bl@1.0.3": {
+      "buffer": "github:jspm/nodelibs-buffer@0.1.0",
+      "readable-stream": "npm:readable-stream@2.0.5",
+      "util": "github:jspm/nodelibs-util@0.1.0"
+    },
+    "npm:bluebird@3.3.3": {
+      "process": "github:jspm/nodelibs-process@0.1.2"
+    },
     "npm:bn.js@4.10.5": {
       "buffer": "github:jspm/nodelibs-buffer@0.1.0"
+    },
+    "npm:boom@2.10.1": {
+      "hoek": "npm:hoek@2.16.3",
+      "http": "github:jspm/nodelibs-http@1.7.1"
+    },
+    "npm:boxen@0.3.1": {
+      "chalk": "npm:chalk@1.1.1",
+      "filled-array": "npm:filled-array@1.1.0",
+      "object-assign": "npm:object-assign@4.0.1",
+      "repeating": "npm:repeating@2.0.0",
+      "string-width": "npm:string-width@1.0.1",
+      "widest-line": "npm:widest-line@1.0.0"
+    },
+    "npm:brace-expansion@1.1.3": {
+      "balanced-match": "npm:balanced-match@0.3.0",
+      "concat-map": "npm:concat-map@0.0.1"
     },
     "npm:browserify-aes@1.0.6": {
       "buffer": "github:jspm/nodelibs-buffer@0.1.0",
@@ -650,6 +772,14 @@ System.config({
       "parse-asn1": "npm:parse-asn1@5.0.0",
       "stream": "github:jspm/nodelibs-stream@0.1.0"
     },
+    "npm:browserify-zlib@0.1.4": {
+      "assert": "github:jspm/nodelibs-assert@0.1.0",
+      "buffer": "github:jspm/nodelibs-buffer@0.1.0",
+      "pako": "npm:pako@0.2.8",
+      "process": "github:jspm/nodelibs-process@0.1.2",
+      "readable-stream": "npm:readable-stream@2.0.5",
+      "util": "github:jspm/nodelibs-util@0.1.0"
+    },
     "npm:buffer-xor@1.0.3": {
       "buffer": "github:jspm/nodelibs-buffer@0.1.0",
       "systemjs-json": "github:systemjs/plugin-json@0.1.0"
@@ -662,11 +792,74 @@ System.config({
       "isarray": "npm:isarray@1.0.0",
       "process": "github:jspm/nodelibs-process@0.1.2"
     },
+    "npm:chalk@1.1.1": {
+      "ansi-styles": "npm:ansi-styles@2.2.0",
+      "escape-string-regexp": "npm:escape-string-regexp@1.0.5",
+      "has-ansi": "npm:has-ansi@2.0.0",
+      "process": "github:jspm/nodelibs-process@0.1.2",
+      "strip-ansi": "npm:strip-ansi@3.0.1",
+      "supports-color": "npm:supports-color@2.0.0"
+    },
     "npm:cipher-base@1.0.2": {
       "buffer": "github:jspm/nodelibs-buffer@0.1.0",
       "inherits": "npm:inherits@2.0.1",
       "stream": "github:jspm/nodelibs-stream@0.1.0",
       "string_decoder": "github:jspm/nodelibs-string_decoder@0.1.0"
+    },
+    "npm:cli-cursor@1.0.2": {
+      "process": "github:jspm/nodelibs-process@0.1.2",
+      "restore-cursor": "npm:restore-cursor@1.0.1"
+    },
+    "npm:cli-width@1.1.1": {
+      "process": "github:jspm/nodelibs-process@0.1.2",
+      "tty": "github:jspm/nodelibs-tty@0.1.0"
+    },
+    "npm:cli-width@2.1.0": {
+      "process": "github:jspm/nodelibs-process@0.1.2",
+      "tty": "github:jspm/nodelibs-tty@0.1.0"
+    },
+    "npm:clone@1.0.2": {
+      "buffer": "github:jspm/nodelibs-buffer@0.1.0",
+      "vm": "github:jspm/nodelibs-vm@0.1.0"
+    },
+    "npm:code-point-at@1.0.0": {
+      "number-is-nan": "npm:number-is-nan@1.0.0"
+    },
+    "npm:columnify@1.5.4": {
+      "process": "github:jspm/nodelibs-process@0.1.2",
+      "strip-ansi": "npm:strip-ansi@3.0.1",
+      "wcwidth": "npm:wcwidth@1.0.0"
+    },
+    "npm:combined-stream@1.0.5": {
+      "buffer": "github:jspm/nodelibs-buffer@0.1.0",
+      "delayed-stream": "npm:delayed-stream@1.0.0",
+      "stream": "github:jspm/nodelibs-stream@0.1.0",
+      "util": "github:jspm/nodelibs-util@0.1.0"
+    },
+    "npm:commander@2.9.0": {
+      "child_process": "github:jspm/nodelibs-child_process@0.1.0",
+      "events": "github:jspm/nodelibs-events@0.1.1",
+      "fs": "github:jspm/nodelibs-fs@0.1.2",
+      "graceful-readlink": "npm:graceful-readlink@1.0.1",
+      "path": "github:jspm/nodelibs-path@0.1.0",
+      "process": "github:jspm/nodelibs-process@0.1.2"
+    },
+    "npm:concat-stream@1.5.1": {
+      "buffer": "github:jspm/nodelibs-buffer@0.1.0",
+      "inherits": "npm:inherits@2.0.1",
+      "readable-stream": "npm:readable-stream@2.0.5",
+      "typedarray": "npm:typedarray@0.0.6"
+    },
+    "npm:configstore@1.4.0": {
+      "graceful-fs": "npm:graceful-fs@4.1.3",
+      "mkdirp": "npm:mkdirp@0.5.1",
+      "object-assign": "npm:object-assign@4.0.1",
+      "os-tmpdir": "npm:os-tmpdir@1.0.1",
+      "osenv": "npm:osenv@0.1.3",
+      "path": "github:jspm/nodelibs-path@0.1.0",
+      "uuid": "npm:uuid@2.0.1",
+      "write-file-atomic": "npm:write-file-atomic@1.1.4",
+      "xdg-basedir": "npm:xdg-basedir@2.0.0"
     },
     "npm:constants-browserify@0.0.1": {
       "systemjs-json": "github:systemjs/plugin-json@0.1.0"
@@ -679,6 +872,10 @@ System.config({
       "buffer": "github:jspm/nodelibs-buffer@0.1.0",
       "crypto": "github:jspm/nodelibs-crypto@0.1.0",
       "elliptic": "npm:elliptic@6.2.3"
+    },
+    "npm:create-error-class@2.0.1": {
+      "capture-stack-trace": "npm:capture-stack-trace@1.0.0",
+      "inherits": "npm:inherits@2.0.1"
     },
     "npm:create-hash@1.1.2": {
       "buffer": "github:jspm/nodelibs-buffer@0.1.0",
@@ -696,6 +893,10 @@ System.config({
       "inherits": "npm:inherits@2.0.1",
       "stream": "github:jspm/nodelibs-stream@0.1.0"
     },
+    "npm:cryptiles@2.0.5": {
+      "boom": "npm:boom@2.10.1",
+      "crypto": "github:jspm/nodelibs-crypto@0.1.0"
+    },
     "npm:crypto-browserify@3.11.0": {
       "browserify-cipher": "npm:browserify-cipher@1.0.0",
       "browserify-sign": "npm:browserify-sign@4.0.0",
@@ -708,10 +909,38 @@ System.config({
       "public-encrypt": "npm:public-encrypt@4.0.0",
       "randombytes": "npm:randombytes@2.0.3"
     },
+    "npm:dashdash@1.13.0": {
+      "assert-plus": "npm:assert-plus@1.0.0",
+      "fs": "github:jspm/nodelibs-fs@0.1.2",
+      "path": "github:jspm/nodelibs-path@0.1.0",
+      "process": "github:jspm/nodelibs-process@0.1.2",
+      "util": "github:jspm/nodelibs-util@0.1.0"
+    },
+    "npm:debug@2.2.0": {
+      "fs": "github:jspm/nodelibs-fs@0.1.2",
+      "ms": "npm:ms@0.7.1",
+      "net": "github:jspm/nodelibs-net@0.1.2",
+      "process": "github:jspm/nodelibs-process@0.1.2",
+      "tty": "github:jspm/nodelibs-tty@0.1.0",
+      "util": "github:jspm/nodelibs-util@0.1.0"
+    },
+    "npm:deep-extend@0.4.1": {
+      "buffer": "github:jspm/nodelibs-buffer@0.1.0"
+    },
+    "npm:defaults@1.0.3": {
+      "clone": "npm:clone@1.0.2"
+    },
+    "npm:delayed-stream@1.0.0": {
+      "stream": "github:jspm/nodelibs-stream@0.1.0",
+      "util": "github:jspm/nodelibs-util@0.1.0"
+    },
     "npm:des.js@1.0.0": {
       "buffer": "github:jspm/nodelibs-buffer@0.1.0",
       "inherits": "npm:inherits@2.0.1",
       "minimalistic-assert": "npm:minimalistic-assert@1.0.0"
+    },
+    "npm:detect-indent@4.0.0": {
+      "repeating": "npm:repeating@2.0.0"
     },
     "npm:diffie-hellman@5.0.2": {
       "bn.js": "npm:bn.js@4.10.5",
@@ -721,12 +950,27 @@ System.config({
       "randombytes": "npm:randombytes@2.0.3",
       "systemjs-json": "github:systemjs/plugin-json@0.1.0"
     },
+    "npm:duplexer2@0.1.4": {
+      "readable-stream": "npm:readable-stream@2.0.5"
+    },
+    "npm:ecc-jsbn@0.1.1": {
+      "buffer": "github:jspm/nodelibs-buffer@0.1.0",
+      "crypto": "github:jspm/nodelibs-crypto@0.1.0",
+      "jsbn": "npm:jsbn@0.1.0"
+    },
+    "npm:elegant-spinner@1.0.1": {
+      "process": "github:jspm/nodelibs-process@0.1.2"
+    },
     "npm:elliptic@6.2.3": {
       "bn.js": "npm:bn.js@4.10.5",
       "brorand": "npm:brorand@1.0.5",
       "hash.js": "npm:hash.js@1.0.3",
       "inherits": "npm:inherits@2.0.1",
       "systemjs-json": "github:systemjs/plugin-json@0.1.0"
+    },
+    "npm:error-ex@1.3.0": {
+      "is-arrayish": "npm:is-arrayish@0.2.1",
+      "util": "github:jspm/nodelibs-util@0.1.0"
     },
     "npm:es6-promise@3.1.2": {
       "process": "github:jspm/nodelibs-process@0.1.2"
@@ -739,15 +983,398 @@ System.config({
       "create-hash": "npm:create-hash@1.1.2",
       "crypto": "github:jspm/nodelibs-crypto@0.1.0"
     },
+    "npm:exit-hook@1.1.1": {
+      "process": "github:jspm/nodelibs-process@0.1.2"
+    },
+    "npm:extsprintf@1.0.2": {
+      "assert": "github:jspm/nodelibs-assert@0.1.0",
+      "util": "github:jspm/nodelibs-util@0.1.0"
+    },
+    "npm:figures@1.4.0": {
+      "process": "github:jspm/nodelibs-process@0.1.2"
+    },
+    "npm:forever-agent@0.6.1": {
+      "http": "github:jspm/nodelibs-http@1.7.1",
+      "https": "github:jspm/nodelibs-https@0.1.0",
+      "net": "github:jspm/nodelibs-net@0.1.2",
+      "tls": "github:jspm/nodelibs-tls@0.1.0",
+      "util": "github:jspm/nodelibs-util@0.1.0"
+    },
+    "npm:form-data@1.0.0-rc3": {
+      "async": "npm:async@1.5.2",
+      "buffer": "github:jspm/nodelibs-buffer@0.1.0",
+      "combined-stream": "npm:combined-stream@1.0.5",
+      "fs": "github:jspm/nodelibs-fs@0.1.2",
+      "http": "github:jspm/nodelibs-http@1.7.1",
+      "https": "github:jspm/nodelibs-https@0.1.0",
+      "mime-types": "npm:mime-types@2.1.10",
+      "path": "github:jspm/nodelibs-path@0.1.0",
+      "process": "github:jspm/nodelibs-process@0.1.2",
+      "url": "github:jspm/nodelibs-url@0.1.0",
+      "util": "github:jspm/nodelibs-util@0.1.0"
+    },
+    "npm:generate-function@2.0.0": {
+      "util": "github:jspm/nodelibs-util@0.1.0"
+    },
+    "npm:generate-object-property@1.2.0": {
+      "is-property": "npm:is-property@1.0.2"
+    },
+    "npm:glob@7.0.3": {
+      "assert": "github:jspm/nodelibs-assert@0.1.0",
+      "events": "github:jspm/nodelibs-events@0.1.1",
+      "fs": "github:jspm/nodelibs-fs@0.1.2",
+      "inflight": "npm:inflight@1.0.4",
+      "inherits": "npm:inherits@2.0.1",
+      "minimatch": "npm:minimatch@3.0.0",
+      "once": "npm:once@1.3.3",
+      "path": "github:jspm/nodelibs-path@0.1.0",
+      "path-is-absolute": "npm:path-is-absolute@1.0.0",
+      "process": "github:jspm/nodelibs-process@0.1.2",
+      "util": "github:jspm/nodelibs-util@0.1.0"
+    },
+    "npm:got@5.5.0": {
+      "buffer": "github:jspm/nodelibs-buffer@0.1.0",
+      "create-error-class": "npm:create-error-class@2.0.1",
+      "duplexer2": "npm:duplexer2@0.1.4",
+      "events": "github:jspm/nodelibs-events@0.1.1",
+      "http": "github:jspm/nodelibs-http@1.7.1",
+      "https": "github:jspm/nodelibs-https@0.1.0",
+      "is-plain-obj": "npm:is-plain-obj@1.1.0",
+      "is-redirect": "npm:is-redirect@1.0.0",
+      "is-retry-allowed": "npm:is-retry-allowed@1.0.0",
+      "is-stream": "npm:is-stream@1.0.1",
+      "lowercase-keys": "npm:lowercase-keys@1.0.0",
+      "node-status-codes": "npm:node-status-codes@1.0.0",
+      "object-assign": "npm:object-assign@4.0.1",
+      "parse-json": "npm:parse-json@2.2.0",
+      "pinkie-promise": "npm:pinkie-promise@2.0.0",
+      "querystring": "github:jspm/nodelibs-querystring@0.1.0",
+      "read-all-stream": "npm:read-all-stream@3.1.0",
+      "readable-stream": "npm:readable-stream@2.0.5",
+      "systemjs-json": "github:systemjs/plugin-json@0.1.0",
+      "timed-out": "npm:timed-out@2.0.0",
+      "url": "github:jspm/nodelibs-url@0.1.0",
+      "url-parse-lax": "npm:url-parse-lax@1.0.0"
+    },
+    "npm:graceful-fs@4.1.3": {
+      "assert": "github:jspm/nodelibs-assert@0.1.0",
+      "constants": "github:jspm/nodelibs-constants@0.1.0",
+      "fs": "github:jspm/nodelibs-fs@0.1.2",
+      "process": "github:jspm/nodelibs-process@0.1.2",
+      "stream": "github:jspm/nodelibs-stream@0.1.0",
+      "util": "github:jspm/nodelibs-util@0.1.0"
+    },
+    "npm:graceful-readlink@1.0.1": {
+      "fs": "github:jspm/nodelibs-fs@0.1.2"
+    },
+    "npm:har-validator@2.0.6": {
+      "chalk": "npm:chalk@1.1.1",
+      "commander": "npm:commander@2.9.0",
+      "is-my-json-valid": "npm:is-my-json-valid@2.13.1",
+      "pinkie-promise": "npm:pinkie-promise@2.0.0",
+      "systemjs-json": "github:systemjs/plugin-json@0.1.0"
+    },
+    "npm:has-ansi@2.0.0": {
+      "ansi-regex": "npm:ansi-regex@2.0.0"
+    },
+    "npm:has@1.0.1": {
+      "function-bind": "npm:function-bind@1.1.0"
+    },
     "npm:hash.js@1.0.3": {
       "inherits": "npm:inherits@2.0.1"
+    },
+    "npm:hawk@3.1.3": {
+      "boom": "npm:boom@2.10.1",
+      "cryptiles": "npm:cryptiles@2.0.5",
+      "crypto": "github:jspm/nodelibs-crypto@0.1.0",
+      "hoek": "npm:hoek@2.16.3",
+      "process": "github:jspm/nodelibs-process@0.1.2",
+      "sntp": "npm:sntp@1.0.9",
+      "systemjs-json": "github:systemjs/plugin-json@0.1.0",
+      "url": "github:jspm/nodelibs-url@0.1.0"
+    },
+    "npm:hoek@2.16.3": {
+      "buffer": "github:jspm/nodelibs-buffer@0.1.0",
+      "crypto": "github:jspm/nodelibs-crypto@0.1.0",
+      "path": "github:jspm/nodelibs-path@0.1.0",
+      "process": "github:jspm/nodelibs-process@0.1.2",
+      "util": "github:jspm/nodelibs-util@0.1.0"
+    },
+    "npm:http-proxy-agent@1.0.0": {
+      "agent-base": "npm:agent-base@2.0.1",
+      "buffer": "github:jspm/nodelibs-buffer@0.1.0",
+      "debug": "npm:debug@2.2.0",
+      "extend": "npm:extend@3.0.0",
+      "net": "github:jspm/nodelibs-net@0.1.2",
+      "tls": "github:jspm/nodelibs-tls@0.1.0",
+      "url": "github:jspm/nodelibs-url@0.1.0",
+      "util": "github:jspm/nodelibs-util@0.1.0"
+    },
+    "npm:http-signature@1.1.1": {
+      "assert-plus": "npm:assert-plus@0.2.0",
+      "buffer": "github:jspm/nodelibs-buffer@0.1.0",
+      "crypto": "github:jspm/nodelibs-crypto@0.1.0",
+      "http": "github:jspm/nodelibs-http@1.7.1",
+      "jsprim": "npm:jsprim@1.2.2",
+      "sshpk": "npm:sshpk@1.7.4",
+      "util": "github:jspm/nodelibs-util@0.1.0"
+    },
+    "npm:https-browserify@0.0.0": {
+      "http": "github:jspm/nodelibs-http@1.7.1"
+    },
+    "npm:https-proxy-agent@1.0.0": {
+      "agent-base": "npm:agent-base@2.0.1",
+      "buffer": "github:jspm/nodelibs-buffer@0.1.0",
+      "debug": "npm:debug@2.2.0",
+      "extend": "npm:extend@3.0.0",
+      "net": "github:jspm/nodelibs-net@0.1.2",
+      "tls": "github:jspm/nodelibs-tls@0.1.0",
+      "url": "github:jspm/nodelibs-url@0.1.0",
+      "util": "github:jspm/nodelibs-util@0.1.0"
+    },
+    "npm:inflight@1.0.4": {
+      "once": "npm:once@1.3.3",
+      "process": "github:jspm/nodelibs-process@0.1.2",
+      "wrappy": "npm:wrappy@1.0.1"
     },
     "npm:inherits@2.0.1": {
       "util": "github:jspm/nodelibs-util@0.1.0"
     },
+    "npm:ini@1.3.4": {
+      "process": "github:jspm/nodelibs-process@0.1.2"
+    },
+    "npm:inquirer@0.10.1": {
+      "ansi-escapes": "npm:ansi-escapes@1.2.0",
+      "ansi-regex": "npm:ansi-regex@2.0.0",
+      "assert": "github:jspm/nodelibs-assert@0.1.0",
+      "chalk": "npm:chalk@1.1.1",
+      "cli-cursor": "npm:cli-cursor@1.0.2",
+      "cli-width": "npm:cli-width@1.1.1",
+      "figures": "npm:figures@1.4.0",
+      "lodash": "npm:lodash@3.10.1",
+      "process": "github:jspm/nodelibs-process@0.1.2",
+      "readline": "github:jspm/nodelibs-readline@0.1.0",
+      "readline2": "npm:readline2@1.0.1",
+      "run-async": "npm:run-async@0.1.0",
+      "rx-lite": "npm:rx-lite@3.1.2",
+      "strip-ansi": "npm:strip-ansi@3.0.1",
+      "through": "npm:through@2.3.8",
+      "util": "github:jspm/nodelibs-util@0.1.0"
+    },
+    "npm:inquirer@0.12.0": {
+      "ansi-escapes": "npm:ansi-escapes@1.2.0",
+      "ansi-regex": "npm:ansi-regex@2.0.0",
+      "assert": "github:jspm/nodelibs-assert@0.1.0",
+      "chalk": "npm:chalk@1.1.1",
+      "cli-cursor": "npm:cli-cursor@1.0.2",
+      "cli-width": "npm:cli-width@2.1.0",
+      "figures": "npm:figures@1.4.0",
+      "lodash": "npm:lodash@4.6.1",
+      "process": "github:jspm/nodelibs-process@0.1.2",
+      "readline2": "npm:readline2@1.0.1",
+      "run-async": "npm:run-async@0.1.0",
+      "rx-lite": "npm:rx-lite@3.1.2",
+      "string-width": "npm:string-width@1.0.1",
+      "strip-ansi": "npm:strip-ansi@3.0.1",
+      "through": "npm:through@2.3.8",
+      "util": "github:jspm/nodelibs-util@0.1.0"
+    },
+    "npm:insight@0.7.0": {
+      "async": "npm:async@1.5.2",
+      "chalk": "npm:chalk@1.1.1",
+      "child_process": "github:jspm/nodelibs-child_process@0.1.0",
+      "configstore": "npm:configstore@1.4.0",
+      "inquirer": "npm:inquirer@0.10.1",
+      "lodash.debounce": "npm:lodash.debounce@3.1.1",
+      "object-assign": "npm:object-assign@4.0.1",
+      "os-name": "npm:os-name@1.0.3",
+      "path": "github:jspm/nodelibs-path@0.1.0",
+      "process": "github:jspm/nodelibs-process@0.1.2",
+      "querystring": "github:jspm/nodelibs-querystring@0.1.0",
+      "request": "npm:request@2.69.0",
+      "tough-cookie": "npm:tough-cookie@2.2.1"
+    },
+    "npm:invariant@2.2.0": {
+      "loose-envify": "npm:loose-envify@1.1.0",
+      "process": "github:jspm/nodelibs-process@0.1.2"
+    },
+    "npm:is-absolute@0.2.3": {
+      "is-relative": "npm:is-relative@0.2.1",
+      "is-windows": "npm:is-windows@0.1.1"
+    },
+    "npm:is-finite@1.0.1": {
+      "number-is-nan": "npm:number-is-nan@1.0.0"
+    },
+    "npm:is-fullwidth-code-point@1.0.0": {
+      "number-is-nan": "npm:number-is-nan@1.0.0"
+    },
+    "npm:is-my-json-valid@2.13.1": {
+      "fs": "github:jspm/nodelibs-fs@0.1.2",
+      "generate-function": "npm:generate-function@2.0.0",
+      "generate-object-property": "npm:generate-object-property@1.2.0",
+      "jsonpointer": "npm:jsonpointer@2.0.0",
+      "path": "github:jspm/nodelibs-path@0.1.0",
+      "xtend": "npm:xtend@4.0.1"
+    },
+    "npm:is-npm@1.0.0": {
+      "process": "github:jspm/nodelibs-process@0.1.2"
+    },
+    "npm:is-relative@0.2.1": {
+      "is-unc-path": "npm:is-unc-path@0.1.1"
+    },
+    "npm:is-unc-path@0.1.1": {
+      "unc-path-regex": "npm:unc-path-regex@0.1.1"
+    },
+    "npm:is-windows@0.1.1": {
+      "process": "github:jspm/nodelibs-process@0.1.2"
+    },
+    "npm:isstream@0.1.2": {
+      "events": "github:jspm/nodelibs-events@0.1.1",
+      "stream": "github:jspm/nodelibs-stream@0.1.0",
+      "util": "github:jspm/nodelibs-util@0.1.0"
+    },
+    "npm:jodid25519@1.0.2": {
+      "buffer": "github:jspm/nodelibs-buffer@0.1.0",
+      "crypto": "github:jspm/nodelibs-crypto@0.1.0",
+      "jsbn": "npm:jsbn@0.1.0"
+    },
+    "npm:jsonpointer@2.0.0": {
+      "assert": "github:jspm/nodelibs-assert@0.1.0"
+    },
+    "npm:jsprim@1.2.2": {
+      "assert": "github:jspm/nodelibs-assert@0.1.0",
+      "extsprintf": "npm:extsprintf@1.0.2",
+      "json-schema": "npm:json-schema@0.2.2",
+      "process": "github:jspm/nodelibs-process@0.1.2",
+      "util": "github:jspm/nodelibs-util@0.1.0",
+      "verror": "npm:verror@1.3.6"
+    },
+    "npm:latest-version@2.0.0": {
+      "package-json": "npm:package-json@2.3.1"
+    },
+    "npm:lockfile@1.0.1": {
+      "constants": "github:jspm/nodelibs-constants@0.1.0",
+      "fs": "github:jspm/nodelibs-fs@0.1.2",
+      "os": "github:jspm/nodelibs-os@0.1.0",
+      "process": "github:jspm/nodelibs-process@0.1.2",
+      "util": "github:jspm/nodelibs-util@0.1.0"
+    },
+    "npm:lodash.debounce@3.1.1": {
+      "lodash._getnative": "npm:lodash._getnative@3.9.1"
+    },
+    "npm:lodash@3.10.1": {
+      "process": "github:jspm/nodelibs-process@0.1.2"
+    },
+    "npm:lodash@4.6.1": {
+      "buffer": "github:jspm/nodelibs-buffer@0.1.0",
+      "process": "github:jspm/nodelibs-process@0.1.2"
+    },
+    "npm:log-update@1.0.2": {
+      "ansi-escapes": "npm:ansi-escapes@1.2.0",
+      "cli-cursor": "npm:cli-cursor@1.0.2",
+      "process": "github:jspm/nodelibs-process@0.1.2"
+    },
+    "npm:loose-envify@1.1.0": {
+      "js-tokens": "npm:js-tokens@1.0.2",
+      "process": "github:jspm/nodelibs-process@0.1.2",
+      "stream": "github:jspm/nodelibs-stream@0.1.0",
+      "util": "github:jspm/nodelibs-util@0.1.0"
+    },
+    "npm:lru-cache@4.0.0": {
+      "pseudomap": "npm:pseudomap@1.0.2",
+      "util": "github:jspm/nodelibs-util@0.1.0",
+      "yallist": "npm:yallist@2.0.0"
+    },
+    "npm:make-error-cause@1.0.2": {
+      "make-error": "npm:make-error@1.1.1"
+    },
     "npm:miller-rabin@4.0.0": {
       "bn.js": "npm:bn.js@4.10.5",
       "brorand": "npm:brorand@1.0.5"
+    },
+    "npm:mime-db@1.22.0": {
+      "systemjs-json": "github:systemjs/plugin-json@0.1.0"
+    },
+    "npm:mime-types@2.1.10": {
+      "mime-db": "npm:mime-db@1.22.0",
+      "path": "github:jspm/nodelibs-path@0.1.0"
+    },
+    "npm:minimatch@3.0.0": {
+      "brace-expansion": "npm:brace-expansion@1.1.3",
+      "path": "github:jspm/nodelibs-path@0.1.0"
+    },
+    "npm:mkdirp@0.5.1": {
+      "fs": "github:jspm/nodelibs-fs@0.1.2",
+      "minimist": "npm:minimist@0.0.8",
+      "path": "github:jspm/nodelibs-path@0.1.0",
+      "process": "github:jspm/nodelibs-process@0.1.2"
+    },
+    "npm:mute-stream@0.0.5": {
+      "process": "github:jspm/nodelibs-process@0.1.2",
+      "stream": "github:jspm/nodelibs-stream@0.1.0"
+    },
+    "npm:node-uuid@1.4.7": {
+      "buffer": "github:jspm/nodelibs-buffer@0.1.0",
+      "crypto": "github:jspm/nodelibs-crypto@0.1.0"
+    },
+    "npm:nopt@1.0.10": {
+      "abbrev": "npm:abbrev@1.0.7",
+      "assert": "github:jspm/nodelibs-assert@0.1.0",
+      "path": "github:jspm/nodelibs-path@0.1.0",
+      "process": "github:jspm/nodelibs-process@0.1.2",
+      "stream": "github:jspm/nodelibs-stream@0.1.0",
+      "url": "github:jspm/nodelibs-url@0.1.0",
+      "util": "github:jspm/nodelibs-util@0.1.0"
+    },
+    "npm:oauth-sign@0.8.1": {
+      "assert": "github:jspm/nodelibs-assert@0.1.0",
+      "crypto": "github:jspm/nodelibs-crypto@0.1.0",
+      "process": "github:jspm/nodelibs-process@0.1.2",
+      "querystring": "github:jspm/nodelibs-querystring@0.1.0"
+    },
+    "npm:once@1.3.3": {
+      "wrappy": "npm:wrappy@1.0.1"
+    },
+    "npm:os-browserify@0.1.2": {
+      "os": "github:jspm/nodelibs-os@0.1.0"
+    },
+    "npm:os-homedir@1.0.1": {
+      "os": "github:jspm/nodelibs-os@0.1.0",
+      "process": "github:jspm/nodelibs-process@0.1.2"
+    },
+    "npm:os-name@1.0.3": {
+      "os": "github:jspm/nodelibs-os@0.1.0",
+      "osx-release": "npm:osx-release@1.1.0",
+      "process": "github:jspm/nodelibs-process@0.1.2",
+      "systemjs-json": "github:systemjs/plugin-json@0.1.0",
+      "win-release": "npm:win-release@1.1.1"
+    },
+    "npm:os-tmpdir@1.0.1": {
+      "process": "github:jspm/nodelibs-process@0.1.2"
+    },
+    "npm:osenv@0.1.3": {
+      "child_process": "github:jspm/nodelibs-child_process@0.1.0",
+      "os-homedir": "npm:os-homedir@1.0.1",
+      "os-tmpdir": "npm:os-tmpdir@1.0.1",
+      "path": "github:jspm/nodelibs-path@0.1.0",
+      "process": "github:jspm/nodelibs-process@0.1.2"
+    },
+    "npm:osx-release@1.1.0": {
+      "minimist": "npm:minimist@1.2.0",
+      "os": "github:jspm/nodelibs-os@0.1.0",
+      "process": "github:jspm/nodelibs-process@0.1.2",
+      "systemjs-json": "github:systemjs/plugin-json@0.1.0"
+    },
+    "npm:package-json@2.3.1": {
+      "got": "npm:got@5.5.0",
+      "process": "github:jspm/nodelibs-process@0.1.2",
+      "rc": "npm:rc@1.1.6",
+      "registry-url": "npm:registry-url@3.0.3",
+      "semver": "npm:semver@5.1.0"
+    },
+    "npm:pako@0.2.8": {
+      "buffer": "github:jspm/nodelibs-buffer@0.1.0",
+      "process": "github:jspm/nodelibs-process@0.1.2"
     },
     "npm:parse-asn1@5.0.0": {
       "asn1.js": "npm:asn1.js@4.5.1",
@@ -758,7 +1385,13 @@ System.config({
       "pbkdf2": "npm:pbkdf2@3.0.4",
       "systemjs-json": "github:systemjs/plugin-json@0.1.0"
     },
+    "npm:parse-json@2.2.0": {
+      "error-ex": "npm:error-ex@1.3.0"
+    },
     "npm:path-browserify@0.0.0": {
+      "process": "github:jspm/nodelibs-process@0.1.2"
+    },
+    "npm:path-is-absolute@1.0.0": {
       "process": "github:jspm/nodelibs-process@0.1.2"
     },
     "npm:pbkdf2@3.0.4": {
@@ -770,8 +1403,46 @@ System.config({
       "process": "github:jspm/nodelibs-process@0.1.2",
       "systemjs-json": "github:systemjs/plugin-json@0.1.0"
     },
+    "npm:pinkie-promise@2.0.0": {
+      "pinkie": "npm:pinkie@2.0.4"
+    },
+    "npm:popsicle-proxy-agent@1.0.0": {
+      "http-proxy-agent": "npm:http-proxy-agent@1.0.0",
+      "https-proxy-agent": "npm:https-proxy-agent@1.0.0",
+      "process": "github:jspm/nodelibs-process@0.1.2",
+      "url": "github:jspm/nodelibs-url@0.1.0"
+    },
+    "npm:popsicle-retry@1.0.1": {
+      "any-promise": "npm:any-promise@1.1.0"
+    },
+    "npm:popsicle@4.0.0": {
+      "any-promise": "npm:any-promise@1.1.0",
+      "arrify": "npm:arrify@1.0.1",
+      "concat-stream": "npm:concat-stream@1.5.1",
+      "fs": "github:jspm/nodelibs-fs@0.1.2",
+      "http": "github:jspm/nodelibs-http@1.7.1",
+      "https": "github:jspm/nodelibs-https@0.1.0",
+      "make-error-cause": "npm:make-error-cause@1.0.2",
+      "methods": "npm:methods@1.1.2",
+      "path": "github:jspm/nodelibs-path@0.1.0",
+      "process": "github:jspm/nodelibs-process@0.1.2",
+      "querystring": "github:jspm/nodelibs-querystring@0.1.0",
+      "stream": "github:jspm/nodelibs-stream@0.1.0",
+      "url": "github:jspm/nodelibs-url@0.1.0",
+      "xtend": "npm:xtend@4.0.1",
+      "zlib": "github:jspm/nodelibs-zlib@0.1.0"
+    },
+    "npm:process-nextick-args@1.0.6": {
+      "process": "github:jspm/nodelibs-process@0.1.2"
+    },
     "npm:process@0.11.2": {
       "assert": "github:jspm/nodelibs-assert@0.1.0"
+    },
+    "npm:promise-finally@2.1.0": {
+      "any-promise": "npm:any-promise@1.1.0"
+    },
+    "npm:pseudomap@1.0.2": {
+      "process": "github:jspm/nodelibs-process@0.1.2"
     },
     "npm:public-encrypt@4.0.0": {
       "bn.js": "npm:bn.js@4.10.5",
@@ -782,10 +1453,28 @@ System.config({
       "parse-asn1": "npm:parse-asn1@5.0.0",
       "randombytes": "npm:randombytes@2.0.3"
     },
+    "npm:punycode@1.3.2": {
+      "process": "github:jspm/nodelibs-process@0.1.2"
+    },
     "npm:randombytes@2.0.3": {
       "buffer": "github:jspm/nodelibs-buffer@0.1.0",
       "crypto": "github:jspm/nodelibs-crypto@0.1.0",
       "process": "github:jspm/nodelibs-process@0.1.2"
+    },
+    "npm:rc@1.1.6": {
+      "deep-extend": "npm:deep-extend@0.4.1",
+      "fs": "github:jspm/nodelibs-fs@0.1.2",
+      "ini": "npm:ini@1.3.4",
+      "minimist": "npm:minimist@1.2.0",
+      "path": "github:jspm/nodelibs-path@0.1.0",
+      "process": "github:jspm/nodelibs-process@0.1.2",
+      "strip-json-comments": "npm:strip-json-comments@1.0.4"
+    },
+    "npm:read-all-stream@3.1.0": {
+      "buffer": "github:jspm/nodelibs-buffer@0.1.0",
+      "pinkie-promise": "npm:pinkie-promise@2.0.0",
+      "readable-stream": "npm:readable-stream@2.0.5",
+      "util": "github:jspm/nodelibs-util@0.1.0"
     },
     "npm:readable-stream@1.1.13": {
       "buffer": "github:jspm/nodelibs-buffer@0.1.0",
@@ -797,6 +1486,24 @@ System.config({
       "stream-browserify": "npm:stream-browserify@1.0.0",
       "string_decoder": "npm:string_decoder@0.10.31"
     },
+    "npm:readable-stream@2.0.5": {
+      "buffer": "github:jspm/nodelibs-buffer@0.1.0",
+      "core-util-is": "npm:core-util-is@1.0.2",
+      "events": "github:jspm/nodelibs-events@0.1.1",
+      "inherits": "npm:inherits@2.0.1",
+      "isarray": "npm:isarray@0.0.1",
+      "process": "github:jspm/nodelibs-process@0.1.2",
+      "process-nextick-args": "npm:process-nextick-args@1.0.6",
+      "string_decoder": "npm:string_decoder@0.10.31",
+      "util-deprecate": "npm:util-deprecate@1.0.2"
+    },
+    "npm:readline2@1.0.1": {
+      "code-point-at": "npm:code-point-at@1.0.0",
+      "is-fullwidth-code-point": "npm:is-fullwidth-code-point@1.0.0",
+      "mute-stream": "npm:mute-stream@0.0.5",
+      "process": "github:jspm/nodelibs-process@0.1.2",
+      "readline": "github:jspm/nodelibs-readline@0.1.0"
+    },
     "npm:reflect-metadata@0.1.2": {
       "assert": "github:jspm/nodelibs-assert@0.1.0",
       "process": "github:jspm/nodelibs-process@0.1.2"
@@ -805,12 +1512,80 @@ System.config({
       "assert": "github:jspm/nodelibs-assert@0.1.0",
       "process": "github:jspm/nodelibs-process@0.1.2"
     },
+    "npm:registry-url@3.0.3": {
+      "rc": "npm:rc@1.1.6"
+    },
+    "npm:repeating@2.0.0": {
+      "is-finite": "npm:is-finite@1.0.1"
+    },
+    "npm:request@2.69.0": {
+      "aws-sign2": "npm:aws-sign2@0.6.0",
+      "aws4": "npm:aws4@1.3.2",
+      "bl": "npm:bl@1.0.3",
+      "buffer": "github:jspm/nodelibs-buffer@0.1.0",
+      "caseless": "npm:caseless@0.11.0",
+      "combined-stream": "npm:combined-stream@1.0.5",
+      "crypto": "github:jspm/nodelibs-crypto@0.1.0",
+      "extend": "npm:extend@3.0.0",
+      "forever-agent": "npm:forever-agent@0.6.1",
+      "form-data": "npm:form-data@1.0.0-rc3",
+      "fs": "github:jspm/nodelibs-fs@0.1.2",
+      "har-validator": "npm:har-validator@2.0.6",
+      "hawk": "npm:hawk@3.1.3",
+      "http": "github:jspm/nodelibs-http@1.7.1",
+      "http-signature": "npm:http-signature@1.1.1",
+      "https": "github:jspm/nodelibs-https@0.1.0",
+      "is-typedarray": "npm:is-typedarray@1.0.0",
+      "isstream": "npm:isstream@0.1.2",
+      "json-stringify-safe": "npm:json-stringify-safe@5.0.1",
+      "mime-types": "npm:mime-types@2.1.10",
+      "node-uuid": "npm:node-uuid@1.4.7",
+      "oauth-sign": "npm:oauth-sign@0.8.1",
+      "process": "github:jspm/nodelibs-process@0.1.2",
+      "qs": "npm:qs@6.0.2",
+      "querystring": "github:jspm/nodelibs-querystring@0.1.0",
+      "stream": "github:jspm/nodelibs-stream@0.1.0",
+      "stringstream": "npm:stringstream@0.0.5",
+      "tough-cookie": "npm:tough-cookie@2.2.1",
+      "tunnel-agent": "npm:tunnel-agent@0.4.2",
+      "url": "github:jspm/nodelibs-url@0.1.0",
+      "util": "github:jspm/nodelibs-util@0.1.0",
+      "zlib": "github:jspm/nodelibs-zlib@0.1.0"
+    },
+    "npm:restore-cursor@1.0.1": {
+      "exit-hook": "npm:exit-hook@1.1.1",
+      "onetime": "npm:onetime@1.1.0",
+      "process": "github:jspm/nodelibs-process@0.1.2"
+    },
+    "npm:rimraf@2.5.2": {
+      "assert": "github:jspm/nodelibs-assert@0.1.0",
+      "fs": "github:jspm/nodelibs-fs@0.1.2",
+      "glob": "npm:glob@7.0.3",
+      "path": "github:jspm/nodelibs-path@0.1.0",
+      "process": "github:jspm/nodelibs-process@0.1.2"
+    },
     "npm:ripemd160@1.0.1": {
       "buffer": "github:jspm/nodelibs-buffer@0.1.0",
       "process": "github:jspm/nodelibs-process@0.1.2"
     },
+    "npm:run-async@0.1.0": {
+      "assert": "github:jspm/nodelibs-assert@0.1.0",
+      "once": "npm:once@1.3.3"
+    },
+    "npm:rx-lite@3.1.2": {
+      "process": "github:jspm/nodelibs-process@0.1.2"
+    },
     "npm:rxjs@5.0.0-beta.2": {
       "buffer": "github:jspm/nodelibs-buffer@0.1.0",
+      "process": "github:jspm/nodelibs-process@0.1.2"
+    },
+    "npm:semver-diff@2.1.0": {
+      "semver": "npm:semver@5.1.0"
+    },
+    "npm:semver@5.0.3": {
+      "process": "github:jspm/nodelibs-process@0.1.2"
+    },
+    "npm:semver@5.1.0": {
       "process": "github:jspm/nodelibs-process@0.1.2"
     },
     "npm:sha.js@2.4.5": {
@@ -819,20 +1594,219 @@ System.config({
       "inherits": "npm:inherits@2.0.1",
       "process": "github:jspm/nodelibs-process@0.1.2"
     },
+    "npm:slide@1.1.6": {
+      "process": "github:jspm/nodelibs-process@0.1.2"
+    },
+    "npm:sntp@1.0.9": {
+      "buffer": "github:jspm/nodelibs-buffer@0.1.0",
+      "dgram": "github:jspm/nodelibs-dgram@0.1.0",
+      "dns": "github:jspm/nodelibs-dns@0.1.0",
+      "hoek": "npm:hoek@2.16.3",
+      "process": "github:jspm/nodelibs-process@0.1.2"
+    },
+    "npm:sort-keys@1.1.1": {
+      "is-plain-obj": "npm:is-plain-obj@1.1.0"
+    },
+    "npm:sshpk@1.7.4": {
+      "asn1": "npm:asn1@0.2.3",
+      "assert-plus": "npm:assert-plus@0.2.0",
+      "buffer": "github:jspm/nodelibs-buffer@0.1.0",
+      "crypto": "github:jspm/nodelibs-crypto@0.1.0",
+      "dashdash": "npm:dashdash@1.13.0",
+      "ecc-jsbn": "npm:ecc-jsbn@0.1.1",
+      "jodid25519": "npm:jodid25519@1.0.2",
+      "jsbn": "npm:jsbn@0.1.0",
+      "stream": "github:jspm/nodelibs-stream@0.1.0",
+      "tweetnacl": "npm:tweetnacl@0.14.1",
+      "util": "github:jspm/nodelibs-util@0.1.0"
+    },
     "npm:stream-browserify@1.0.0": {
       "events": "github:jspm/nodelibs-events@0.1.1",
       "inherits": "npm:inherits@2.0.1",
       "readable-stream": "npm:readable-stream@1.1.13"
     },
+    "npm:string-width@1.0.1": {
+      "code-point-at": "npm:code-point-at@1.0.0",
+      "is-fullwidth-code-point": "npm:is-fullwidth-code-point@1.0.0",
+      "strip-ansi": "npm:strip-ansi@3.0.1"
+    },
     "npm:string_decoder@0.10.31": {
       "buffer": "github:jspm/nodelibs-buffer@0.1.0"
+    },
+    "npm:stringstream@0.0.5": {
+      "buffer": "github:jspm/nodelibs-buffer@0.1.0",
+      "fs": "github:jspm/nodelibs-fs@0.1.2",
+      "process": "github:jspm/nodelibs-process@0.1.2",
+      "stream": "github:jspm/nodelibs-stream@0.1.0",
+      "string_decoder": "github:jspm/nodelibs-string_decoder@0.1.0",
+      "util": "github:jspm/nodelibs-util@0.1.0",
+      "zlib": "github:jspm/nodelibs-zlib@0.1.0"
+    },
+    "npm:strip-ansi@3.0.1": {
+      "ansi-regex": "npm:ansi-regex@2.0.0"
+    },
+    "npm:strip-bom@2.0.0": {
+      "buffer": "github:jspm/nodelibs-buffer@0.1.0",
+      "is-utf8": "npm:is-utf8@0.2.1"
+    },
+    "npm:strip-json-comments@1.0.4": {
+      "fs": "github:jspm/nodelibs-fs@0.1.2",
+      "process": "github:jspm/nodelibs-process@0.1.2",
+      "systemjs-json": "github:systemjs/plugin-json@0.1.0"
+    },
+    "npm:supports-color@2.0.0": {
+      "process": "github:jspm/nodelibs-process@0.1.2"
+    },
+    "npm:thenify@3.2.0": {
+      "any-promise": "npm:any-promise@1.1.0",
+      "assert": "github:jspm/nodelibs-assert@0.1.0"
+    },
+    "npm:through@2.3.8": {
+      "process": "github:jspm/nodelibs-process@0.1.2",
+      "stream": "github:jspm/nodelibs-stream@0.1.0"
+    },
+    "npm:timers-browserify@1.4.2": {
+      "process": "npm:process@0.11.2"
+    },
+    "npm:touch@1.0.0": {
+      "constants": "github:jspm/nodelibs-constants@0.1.0",
+      "fs": "github:jspm/nodelibs-fs@0.1.2",
+      "nopt": "npm:nopt@1.0.10",
+      "path": "github:jspm/nodelibs-path@0.1.0"
+    },
+    "npm:tough-cookie@2.2.1": {
+      "net": "github:jspm/nodelibs-net@0.1.2",
+      "punycode": "github:jspm/nodelibs-punycode@0.1.0",
+      "systemjs-json": "github:systemjs/plugin-json@0.1.0",
+      "url": "github:jspm/nodelibs-url@0.1.0",
+      "util": "github:jspm/nodelibs-util@0.1.0"
+    },
+    "npm:tunnel-agent@0.4.2": {
+      "assert": "github:jspm/nodelibs-assert@0.1.0",
+      "buffer": "github:jspm/nodelibs-buffer@0.1.0",
+      "events": "github:jspm/nodelibs-events@0.1.1",
+      "http": "github:jspm/nodelibs-http@1.7.1",
+      "https": "github:jspm/nodelibs-https@0.1.0",
+      "net": "github:jspm/nodelibs-net@0.1.2",
+      "process": "github:jspm/nodelibs-process@0.1.2",
+      "tls": "github:jspm/nodelibs-tls@0.1.0",
+      "util": "github:jspm/nodelibs-util@0.1.0"
+    },
+    "npm:typings@0.6.10": {
+      "any-promise": "npm:any-promise@1.1.0",
+      "archy": "npm:archy@1.0.0",
+      "array-uniq": "npm:array-uniq@1.0.2",
+      "bluebird": "npm:bluebird@3.3.3",
+      "chalk": "npm:chalk@1.1.1",
+      "child_process": "github:jspm/nodelibs-child_process@0.1.0",
+      "columnify": "npm:columnify@1.5.4",
+      "debug": "npm:debug@2.2.0",
+      "detect-indent": "npm:detect-indent@4.0.0",
+      "elegant-spinner": "npm:elegant-spinner@1.0.1",
+      "graceful-fs": "npm:graceful-fs@4.1.3",
+      "has": "npm:has@1.0.1",
+      "inquirer": "npm:inquirer@0.12.0",
+      "insight": "npm:insight@0.7.0",
+      "invariant": "npm:invariant@2.2.0",
+      "is-absolute": "npm:is-absolute@0.2.3",
+      "listify": "npm:listify@1.0.0",
+      "lockfile": "npm:lockfile@1.0.1",
+      "log-update": "npm:log-update@1.0.2",
+      "make-error-cause": "npm:make-error-cause@1.0.2",
+      "minimist": "npm:minimist@1.2.0",
+      "mkdirp": "npm:mkdirp@0.5.1",
+      "object.pick": "npm:object.pick@1.1.1",
+      "os": "github:jspm/nodelibs-os@0.1.0",
+      "parse-json": "npm:parse-json@2.2.0",
+      "path": "github:jspm/nodelibs-path@0.1.0",
+      "popsicle": "npm:popsicle@4.0.0",
+      "popsicle-proxy-agent": "npm:popsicle-proxy-agent@1.0.0",
+      "popsicle-retry": "npm:popsicle-retry@1.0.1",
+      "popsicle-status": "npm:popsicle-status@1.0.1",
+      "process": "github:jspm/nodelibs-process@0.1.2",
+      "promise-finally": "npm:promise-finally@2.1.0",
+      "querystring": "github:jspm/nodelibs-querystring@0.1.0",
+      "rc": "npm:rc@1.1.6",
+      "rimraf": "npm:rimraf@2.5.2",
+      "sort-keys": "npm:sort-keys@1.1.1",
+      "string-template": "npm:string-template@1.0.0",
+      "strip-bom": "npm:strip-bom@2.0.0",
+      "systemjs-json": "github:systemjs/plugin-json@0.1.0",
+      "thenify": "npm:thenify@3.2.0",
+      "touch": "npm:touch@1.0.0",
+      "typescript": "npm:typescript@1.8.7",
+      "update-notifier": "npm:update-notifier@0.6.1",
+      "url": "github:jspm/nodelibs-url@0.1.0",
+      "wordwrap": "npm:wordwrap@1.0.0",
+      "xtend": "npm:xtend@4.0.1",
+      "zip-object": "npm:zip-object@0.1.0"
+    },
+    "npm:update-notifier@0.6.1": {
+      "boxen": "npm:boxen@0.3.1",
+      "chalk": "npm:chalk@1.1.1",
+      "child_process": "github:jspm/nodelibs-child_process@0.1.0",
+      "configstore": "npm:configstore@1.4.0",
+      "is-npm": "npm:is-npm@1.0.0",
+      "latest-version": "npm:latest-version@2.0.0",
+      "path": "github:jspm/nodelibs-path@0.1.0",
+      "process": "github:jspm/nodelibs-process@0.1.2",
+      "semver-diff": "npm:semver-diff@2.1.0"
+    },
+    "npm:url-parse-lax@1.0.0": {
+      "prepend-http": "npm:prepend-http@1.0.3",
+      "url": "github:jspm/nodelibs-url@0.1.0"
+    },
+    "npm:url@0.10.3": {
+      "assert": "github:jspm/nodelibs-assert@0.1.0",
+      "punycode": "npm:punycode@1.3.2",
+      "querystring": "npm:querystring@0.2.0",
+      "util": "github:jspm/nodelibs-util@0.1.0"
+    },
+    "npm:util-deprecate@1.0.2": {
+      "util": "github:jspm/nodelibs-util@0.1.0"
     },
     "npm:util@0.10.3": {
       "inherits": "npm:inherits@2.0.1",
       "process": "github:jspm/nodelibs-process@0.1.2"
     },
+    "npm:uuid@2.0.1": {
+      "assert": "github:jspm/nodelibs-assert@0.1.0",
+      "child_process": "github:jspm/nodelibs-child_process@0.1.0",
+      "crypto": "github:jspm/nodelibs-crypto@0.1.0",
+      "os": "github:jspm/nodelibs-os@0.1.0",
+      "util": "github:jspm/nodelibs-util@0.1.0"
+    },
+    "npm:verror@1.3.6": {
+      "assert": "github:jspm/nodelibs-assert@0.1.0",
+      "extsprintf": "npm:extsprintf@1.0.2",
+      "fs": "github:jspm/nodelibs-fs@0.1.2",
+      "util": "github:jspm/nodelibs-util@0.1.0"
+    },
     "npm:vm-browserify@0.0.4": {
       "indexof": "npm:indexof@0.0.1"
+    },
+    "npm:wcwidth@1.0.0": {
+      "defaults": "npm:defaults@1.0.3"
+    },
+    "npm:widest-line@1.0.0": {
+      "string-width": "npm:string-width@1.0.1"
+    },
+    "npm:win-release@1.1.1": {
+      "child_process": "github:jspm/nodelibs-child_process@0.1.0",
+      "os": "github:jspm/nodelibs-os@0.1.0",
+      "process": "github:jspm/nodelibs-process@0.1.2",
+      "semver": "npm:semver@5.1.0"
+    },
+    "npm:write-file-atomic@1.1.4": {
+      "graceful-fs": "npm:graceful-fs@4.1.3",
+      "imurmurhash": "npm:imurmurhash@0.1.4",
+      "process": "github:jspm/nodelibs-process@0.1.2",
+      "slide": "npm:slide@1.1.6"
+    },
+    "npm:xdg-basedir@2.0.0": {
+      "os-homedir": "npm:os-homedir@1.0.1",
+      "path": "github:jspm/nodelibs-path@0.1.0",
+      "process": "github:jspm/nodelibs-process@0.1.2"
     },
     "npm:zone.js@0.5.15": {
       "es6-promise": "npm:es6-promise@3.1.2",

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -40,8 +40,8 @@ gulp.task('jspm:bundle:dist', () => {
   return gulp
     .src('./src/main.ts')
     .pipe(sourcemaps.init())
-      .pipe(jspm({ selfExecutingBundle: true, minify: true, mangle: false }))
-      .pipe(rename('backsaw.min.js'))
+    .pipe(jspm({ selfExecutingBundle: true, minify: true, mangle: false }))
+    .pipe(rename('backsaw.min.js'))
     .pipe(sourcemaps.write('.'))
     .pipe(gulp.dest('./.dist/scripts/'));
 });

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "deploy": "gulp deploy",
     "start": "gulp start",
     "start:dist": "gulp start:dist",
-    "test": "gulp test"
+    "test": "gulp test",
+    "postinstall": "typings install"
   },
   "dependencies": {},
   "devDependencies": {
@@ -38,7 +39,8 @@
     "jspm": "^0.16.30",
     "lite-server": "^2.1.0",
     "run-sequence": "^1.1.5",
-    "rxjs": "^5.0.0-beta.2"
+    "rxjs": "^5.0.0-beta.2",
+    "typings": "^0.6.8"
   },
   "engines": {
     "node": "^5.7.0"
@@ -54,7 +56,8 @@
       "zone.js": "npm:zone.js@^0.5.15"
     },
     "devDependencies": {
-      "typescript": "npm:typescript@^1.8.2"
+      "typescript": "npm:typescript@^1.8.2",
+      "typings": "npm:typings@^0.6.8"
     }
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,10 +8,12 @@
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
     "removeComments": false,
-    "noImplicitAny": false
+    "noImplicitAny": true
   },
   "exclude": [
     "node_modules",
-    "jspm_packages"
+    "jspm_packages",
+    "typings/main",
+    "typings/main.d.ts"
   ]
 }

--- a/tslint.json
+++ b/tslint.json
@@ -16,12 +16,7 @@
     "no-internal-module": true,
     "no-var-requires": true,
     "typedef": [
-      true,
-      "call-signature",
-      "parameter",
-      "arrow-parameter",
-      "property-declaration",
-      "member-variable-declaration"
+      false
     ],
     "typedef-whitespace": [
       true,

--- a/typings.json
+++ b/typings.json
@@ -1,0 +1,5 @@
+{
+  "ambientDependencies": {
+    "es6-shim": "github:DefinitelyTyped/DefinitelyTyped/es6-shim/es6-shim.d.ts#4de74cb527395c13ba20b438c3a7a419ad931f1c"
+  }
+}


### PR DESCRIPTION
This solves the issue where the es6 shim was not used by the editor, and so es6 methods like `find` were considered errors. It does this by using `typings` npm module to load the type definition file for the es6 shim.

It also changes the way noImplictAny is handled, and prevents it from being allowed by tsc, but then also removes the duplicative typedef linting.
