### PR TITLE
Add keywords to report

### DIFF
--- a/src/app/report/report-details.component.html
+++ b/src/app/report/report-details.component.html
@@ -22,4 +22,5 @@
     </thead>
     <slot-report-details *ngFor="#slotId of slotIds" [slotId]="slotId" [adzerkResponses$]="adzerkResponses$" [filteredAdzerkResponses$]="filteredAdzerkResponses$" [filter]="filter"></slot-report-details>
   </table>
+  <report-keywords *ngIf="keywords.length > 0" [keywords]="keywords"></report-keywords>
 </div>

--- a/src/app/report/report-details.component.html
+++ b/src/app/report/report-details.component.html
@@ -22,5 +22,5 @@
     </thead>
     <slot-report-details *ngFor="#slotId of slotIds" [slotId]="slotId" [adzerkResponses$]="adzerkResponses$" [filteredAdzerkResponses$]="filteredAdzerkResponses$" [filter]="filter"></slot-report-details>
   </table>
-  <report-keywords *ngIf="keywords.length > 0" [keywords]="keywords"></report-keywords>
+  <report-keywords *ngIf="keywords.length > 0" [idKeyword]="keywords[0]" [keywords]="keywords.slice(1)"></report-keywords>
 </div>

--- a/src/app/report/report-details.component.ts
+++ b/src/app/report/report-details.component.ts
@@ -4,10 +4,11 @@ import {Observable} from 'rxjs/Observable';
 
 import {AdzerkNativeAdAPIResponse} from '../services/adzerk_native_ad_api_client';
 import {SlotReportDetailsComponent} from './slot-report-details.component';
+import {ReportKeywordsComponent} from './report-keywords.component';
 import {ReportService} from '../services/report.service';
 
 @Component({
-  directives: [SlotReportDetailsComponent],
+  directives: [SlotReportDetailsComponent, ReportKeywordsComponent],
   selector: 'report-details',
   styleUrls: ['app/report/report-details.component.css'],
   templateUrl: 'app/report/report-details.component.html'
@@ -16,6 +17,7 @@ export class ReportDetailsComponent implements OnInit {
   @Input() adzerkResponses$: Observable<AdzerkNativeAdAPIResponse[]>;
   @Input() filteredAdzerkResponses$: Observable<AdzerkNativeAdAPIResponse[]>;
   @Input() filter: {};
+  @Input() keywords: string[];
 
   adzerkResponses: AdzerkNativeAdAPIResponse[] = [];
   filteredAdzerkResponses: AdzerkNativeAdAPIResponse[] = [];

--- a/src/app/report/report-keywords.component.css
+++ b/src/app/report/report-keywords.component.css
@@ -1,16 +1,37 @@
-div {
+section {
   margin: 30px auto;
   font-family: sans-serif;
-  font-weight: normal;
   border-top: 1px solid #ccc;
   padding-top: 30px;
   width: 60%;
 }
 
-h2 {
-  text-align: center;
-  font-size: 18px;
-  text-transform: uppercase;
+.id-keyword {
+  display: flex;
+  flex-direction: row;
+  height: 40px;
+}
+.id-keyword > input {
+  flex-basis: 70%;
+  color: black;
+  font-size: medium;
+  border: 1px solid #ccc;
+  padding: 5px;
+  font-family: sans-serif;
+  letter-spacing: 1px;
+}
+
+.id-keyword > button {
+  background: #3889a4;
+  border: 0;
+  color: white;
+  font-family: 'Open Sans', sans-serif;
+  font-size: 14px;
+  cursor: pointer;
+}
+
+h4 {
+  font-weight: normal;
 }
 
 ul {

--- a/src/app/report/report-keywords.component.css
+++ b/src/app/report/report-keywords.component.css
@@ -1,0 +1,18 @@
+div {
+  margin: 30px auto;
+  font-family: sans-serif;
+  font-weight: normal;
+  border-top: 1px solid #ccc;
+  padding-top: 30px;
+  width: 60%;
+}
+
+h2 {
+  text-align: center;
+  font-size: 18px;
+  text-transform: uppercase;
+}
+
+ul {
+  font-family: sans-serif;
+}

--- a/src/app/report/report-keywords.component.ts
+++ b/src/app/report/report-keywords.component.ts
@@ -4,16 +4,45 @@ import {Component, Input} from 'angular2/core';
   selector: 'report-keywords',
   styleUrls: ['app/report/report-keywords.component.css'],
   template: `
-    <div>
-      <h2>Keywords for this episode</h2>
+    <section>
+      <h4>This episode's unique identifying keyword:</h4>
+      <div class="id-keyword">
+        <input type="text" readonly [value]="idKeyword" #idKeywordInput>
+        <button
+          (mouseover)="resetCopyButton(copyButton)"
+          (click)="copyCode(idKeywordInput, copyButton)"
+          #copyButton>
+          Copy
+        </button>
+      </div>
+      <h4>Other keywords and tags for this episode:</h4>
       <ul>
         <li *ngFor="#keyword of keywords">
           {{keyword}}
         </li>
       </ul>
-    </div>
+    </section>
   `
 })
 export class ReportKeywordsComponent {
   @Input() keywords: string[];
+  @Input() idKeyword: string[];
+
+  resetCopyButton(el: Element) {
+    el.innerHTML = 'Copy';
+  }
+
+  // Copies the HTML code in an input associated with the button that is passed in
+  copyCode(inp: HTMLInputElement, button: Element) {
+    if (inp && inp.select) {
+      inp.select();
+      try {
+        document.execCommand('copy');
+        inp.blur();
+        button.innerHTML = 'Copied';
+      } catch (err) {
+        alert('please press Ctrl/Cmd+C to copy');
+      }
+    }
+  }
 }

--- a/src/app/report/report-keywords.component.ts
+++ b/src/app/report/report-keywords.component.ts
@@ -1,0 +1,19 @@
+import {Component, Input} from 'angular2/core';
+
+@Component({
+  selector: 'report-keywords',
+  styleUrls: ['app/report/report-keywords.component.css'],
+  template: `
+    <div>
+      <h2>Keywords for this episode</h2>
+      <ul>
+        <li *ngFor="#keyword of keywords">
+          {{keyword}}
+        </li>
+      </ul>
+    </div>
+  `
+})
+export class ReportKeywordsComponent {
+  @Input() keywords: string[];
+}

--- a/src/app/report/report.component.html
+++ b/src/app/report/report.component.html
@@ -16,7 +16,9 @@
   (window:keydown)="clearFilter($event)"
   [adzerkResponses$]="report.adzerkResponses$"
   [filteredAdzerkResponses$]="report.filteredAdzerkResponses$"
-  [filter]="report.filter"></report-details>
+  [filter]="report.filter"
+  [keywords]="episode.keywords"
+  ></report-details>
 
 
 

--- a/src/app/services/program.service.ts
+++ b/src/app/services/program.service.ts
@@ -6,7 +6,8 @@ import {Observable} from 'rxjs/Observable';
 export class Episode {
   constructor(
     public url: string,
-    public title?: string
+    public title?: string,
+    public keywords?: string[]
   ) {}
 
   paramURL(): string {

--- a/src/app/services/report.service.ts
+++ b/src/app/services/report.service.ts
@@ -144,9 +144,7 @@ export class ReportService {
       .getAdzerkRequestBody(this.episode.url)
       .subscribe((request: AdzerkNativeAdAPIRequest) => {
         this.adzerkRequest = request;
-        this.episode.keywords = ["here", "are", "some", "keywords"];
-        // this.episode.keywords = request.keywords;
-        // debugger
+        this.episode.keywords = request.keywords;
       });
 
     this.dovetailService

--- a/src/app/services/report.service.ts
+++ b/src/app/services/report.service.ts
@@ -144,6 +144,9 @@ export class ReportService {
       .getAdzerkRequestBody(this.episode.url)
       .subscribe((request: AdzerkNativeAdAPIRequest) => {
         this.adzerkRequest = request;
+        this.episode.keywords = ["here", "are", "some", "keywords"];
+        // this.episode.keywords = request.keywords;
+        // debugger
       });
 
     this.dovetailService


### PR DESCRIPTION
Re: #19 
Dovetail now sends keywords to Adzerk, for [use in targeting (and in excluding) episodes by keyword](https://dev.adzerk.com/v1.0/docs/keyword-logic). This PR adds the keywords for each episode to their view in Backsaw, highlighting the one unchanging identifier keyword (`keyword_xid` from feeder). Screenshot below in case reviewer has trouble building Backsaw locally. 
![image](https://user-images.githubusercontent.com/16007382/29885311-5c2efff2-8d84-11e7-91a7-9a6da8d9bc8b.png)
